### PR TITLE
Fixes for the orchestrator containers. Go was refusing to build the o…

### DIFF
--- a/conf/orchestrator/Dockerfile
+++ b/conf/orchestrator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:latest
 
 EXPOSE 3000
 
@@ -16,8 +16,8 @@ RUN set -ex \
     && { go get -d github.com/github/orchestrator ; : ; } \
     && cd $GOPATH/src/github.com/github/orchestrator \
     && bash build.sh -b \
-    && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator -maxdepth 2)/ / \
-    && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator-cli -maxdepth 2)/ / \
+    && mkdir -p /usr/local/orchestrator \
+    && cp build/bin/orchestrator /usr/local/orchestrator/ \
     && cd / \
     && apk del .build-deps \
     && rm -rf /tmp/* \


### PR DESCRIPTION
…rchestrator because go version was 1.10, required 1.12. So I upgraded alpine image to the latest. After that I had to fix the file copy because the directory structure apparently changed between versions. docker-compose-init.bash is still giving me problems even after I had created a local alias for orchestrator-client, which with the new version apparently has been replaced with orchestrator cli. It fails on discover with MySQL access denied message printed previously. I have not yet investigated that, but at least docker-compose build succeeds and I can see orchestrator containers coming up and printing messages that suggest they are doing something.