### PR TITLE
Ability to use a local proxysql binary in testing

### DIFF
--- a/conf/orchestrator/Dockerfile
+++ b/conf/orchestrator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:latest
 
 EXPOSE 3000
 
@@ -16,8 +16,8 @@ RUN set -ex \
     && { go get -d github.com/github/orchestrator ; : ; } \
     && cd $GOPATH/src/github.com/github/orchestrator \
     && bash build.sh -b \
-    && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator -maxdepth 2)/ / \
-    && rsync -av $(find /tmp/orchestrator-release -type d -name orchestrator-cli -maxdepth 2)/ / \
+    && mkdir -p /usr/local/orchestrator \
+    && cp build/bin/orchestrator /usr/local/orchestrator/ \
     && cd / \
     && apk del .build-deps \
     && rm -rf /tmp/* \

--- a/docker-compose-init.bash
+++ b/docker-compose-init.bash
@@ -1,4 +1,18 @@
 #!/bin/bash
+
+function die
+{
+	printf "Fatal error: $1" >&2
+	exit
+}
+
+function cp_w_mkdir
+{
+    local src="$1" dst="$2"
+    local d=$(dirname $2)
+    (mkdir -p $d && cp "$src" "$dst" ) || die "Error copying from $src to $dst"
+}
+
 . constants
 
 printf "$BRIGHT"
@@ -9,9 +23,51 @@ printf "$NORMAL"
 
 sleep 1
 
-docker-compose up -d
-./bin/docker-mysql-post.bash && ./bin/docker-orchestrator-post.bash && ./bin/docker-restart-binlog_reader.bash && ./bin/docker-proxy-post.bash
+if [ -z "$PROXYSQL_BIN" ] && [ -x "../proxysql/src/proxysql" ]
+then
+  PROXYSQL_BIN="../proxysql/src/proxysql"
+fi
+
+PROXYSQL_DOCKER_BASE="./conf/proxysql"
+DOCKER_PROXYSQL="$PROXYSQL_DOCKER_BASE/usr/bin/proxysql"
+PROXYSQL_DOCKERBUILD_EXTRA=
+PROXYSQL_DOCKERFILE="$PROXYSQL_DOCKER_BASE/Dockerfile"
+REBUILD_DOCKER=${REBUILD_DOCKER:-0}
+PROXYSQL_BASE_IMAGE="renecannao/proxysql_205_pltx19:debian9"
+
+if [ "$REBUILD_DOCKER" = "1" ]
+then
+    rm -f $PROXYSQL_DOCKERFILE
+fi
+
+if [ ! -f "$PROXYSQL_DOCKERFILE" ]
+then
+    if [ -x "$PROXYSQL_BIN" ]
+    then
+        cp_w_mkdir $PROXYSQL_BIN $DOCKER_PROXYSQL
+        PROXYSQL_BASE_IMAGE="spachev/proxysql-debian-stretch"
+        PROXYSQL_DOCKERBUILD_EXTRA=$(cat <<'eot'
+COPY / /
+eot
+)
+        printf "Found proxysql local binary in $PROXYSQL_BIN, putting it in Docker\n"
+    fi
+
+    cat >$PROXYSQL_DOCKERFILE <<eot
+FROM $PROXYSQL_BASE_IMAGE
+$PROXYSQL_DOCKERBUILD_EXTRA
+eot
+    REBUILD_DOCKER=1
+fi
+
+if [ "$REBUILD_DOCKER" = "1" ]
+then
+    docker-compose build || die "Error building Docker containers"
+fi
+
+docker-compose up -d || die "Error bringing Docker containers up"
+(./bin/docker-mysql-post.bash && ./bin/docker-orchestrator-post.bash && ./bin/docker-restart-binlog_reader.bash && ./bin/docker-proxy-post.bash) || die "Error running setup"
 
 if [[ -z "$1" ]]; then
-    ./bin/docker-benchmark.bash
+    ./bin/docker-benchmark.bash || die "Error running the benchmark"
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.0"
 services:
   mysql1:
     image: mysql:5.7
-    ports: 
+    ports:
       - "13306:3306"
     volumes:
       - ./conf/mysql/mysql1:/etc/mysql/conf.d
@@ -12,7 +12,7 @@ services:
       - MYSQL_ROOT_PASSWORD=root
   mysql2:
     image: mysql:5.7
-    ports: 
+    ports:
       - "13307:3306"
     volumes:
       - ./conf/mysql/mysql2:/etc/mysql/conf.d
@@ -24,7 +24,7 @@ services:
       - MYSQL_ROOT_PASSWORD=root
   mysql3:
     image: mysql:5.7
-    ports: 
+    ports:
       - "13308:3306"
     volumes:
       - ./conf/mysql/mysql3:/etc/mysql/conf.d
@@ -40,7 +40,7 @@ services:
       - "14306:6020"
     volumes:
       - ./entrypoint/reader/reader1:/etc/proxysql_binlog_reader
-    entrypoint: /etc/proxysql_binlog_reader/entrypoint.sh  
+    entrypoint: /etc/proxysql_binlog_reader/entrypoint.sh
     networks:
       - backend
     depends_on:
@@ -51,7 +51,7 @@ services:
       - "14307:6020"
     volumes:
       - ./entrypoint/reader/reader2:/etc/proxysql_binlog_reader
-    entrypoint: /etc/proxysql_binlog_reader/entrypoint.sh  
+    entrypoint: /etc/proxysql_binlog_reader/entrypoint.sh
     networks:
       - backend
     depends_on:
@@ -62,13 +62,13 @@ services:
       - "14308:6020"
     volumes:
       - ./entrypoint/reader/reader3:/etc/proxysql_binlog_reader
-    entrypoint: /etc/proxysql_binlog_reader/entrypoint.sh  
+    entrypoint: /etc/proxysql_binlog_reader/entrypoint.sh
     networks:
       - backend
     depends_on:
       - mysql3
   proxysql1:
-    image: renecannao/proxysql_205_pltx19:debian9
+    build: ./conf/proxysql/
     ports:
       - "16033:6033"
       - "16032:6032"
@@ -83,7 +83,7 @@ services:
       - frontend
       - backend
   proxysql2:
-    image: renecannao/proxysql_205_pltx19:debian9
+    build: ./conf/proxysql/
     ports:
       - "16043:6033"
       - "16042:6032"
@@ -97,7 +97,7 @@ services:
       - frontend
       - backend
   proxysql3:
-    image: renecannao/proxysql_205_pltx19:debian9
+    build: ./conf/proxysql/
     ports:
       - "16053:6033"
       - "16052:6032"


### PR DESCRIPTION
Refactored proxysql containers to use spachev/proxysql-debian-stretch image with proxysql binary replaced with the locally build one if running with REBUILD_DOCKER=1 and if the binary exists - defaulting to ../proxysql/src/proxysql, but can be overrided with PROXYSQL_BIN setting. If running with defaults or if the binary does not exist, use the original renecannao/proxysql_205_pltx19:debian9 image.