### PR TITLE
Change github URL for orchestrator repo

### DIFF
--- a/conf/orchestrator/Dockerfile
+++ b/conf/orchestrator/Dockerfile
@@ -13,8 +13,8 @@ RUN set -ex \
         build-base \
     && apk add mysql-client \
     && cd /tmp \
-    && { go get -d github.com/github/orchestrator ; : ; } \
-    && cd $GOPATH/src/github.com/github/orchestrator \
+    && { go get -d github.com/openark/orchestrator ; : ; } \
+    && cd $GOPATH/src/github.com/openark/orchestrator \
     && bash build.sh -b \
     && mkdir -p /usr/local/orchestrator \
     && cp build/bin/orchestrator /usr/local/orchestrator/ \


### PR DESCRIPTION
The [orchestrator repo](github.com/openark/orchestrator) moved from being under the [github](https://github.com/github) org back to the [openark](https://github.com/openark) org.

Because of this, the `go get` command fails and orchestrator isn't installed when running the `docker-compose-init.bash` script:

```
+ cd /tmp
+ go get -d github.com/github/orchestrator
package github.com/github/orchestrator: no Go files in /tmp/go/src/github.com/github/orchestrator
+ :
+ cd /tmp/go/src/github.com/github/orchestrator
+ bash build.sh -b
[DEBUG] Build only; no packaging
[DEBUG] Building via go version go1.13.10 linux/amd64
go/cmd/orchestrator/main.go:25:2: cannot find package "github.com/openark/orchestrator/go/app" in any of:
	/tmp/go/src/github.com/github/orchestrator/vendor/github.com/openark/orchestrator/go/app (vendor tree)
	/usr/lib/go/src/github.com/openark/orchestrator/go/app (from $GOROOT)
	/tmp/go/src/github.com/openark/orchestrator/go/app (from $GOPATH)
go/cmd/orchestrator/main.go:26:2: cannot find package "github.com/openark/orchestrator/go/config" in any of:
	/tmp/go/src/github.com/github/orchestrator/vendor/github.com/openark/orchestrator/go/config (vendor tree)
	/usr/lib/go/src/github.com/openark/orchestrator/go/config (from $GOROOT)
	/tmp/go/src/github.com/openark/orchestrator/go/config (from $GOPATH)
FROM alpine:latest
go/cmd/orchestrator/main.go:27:2: cannot find package "github.com/openark/orchestrator/go/inst" in any of:
	/tmp/go/src/github.com/github/orchestrator/vendor/github.com/openark/orchestrator/go/inst (vendor tree)
	/usr/lib/go/src/github.com/openark/orchestrator/go/inst (from $GOROOT)
	/tmp/go/src/github.com/openark/orchestrator/go/inst (from $GOPATH)
find: build/bin/orchestrator: No such file or directory
Failed to generate orchestrator binary
```

Changing the URL fixes this:

```
+ cd /tmp
+ go get -d github.com/openark/orchestrator
package github.com/openark/orchestrator: no Go files in /tmp/go/src/github.com/openark/orchestrator
+ :
+ cd /tmp/go/src/github.com/openark/orchestrator
+ bash build.sh -b
[DEBUG] Build only; no packaging
[DEBUG] Building via go version go1.13.10 linux/amd64
build/bin/orchestrator
[DEBUG] orchestrator build done; exit status is 0
+ mkdir -p /usr/local/orchestrator
+ cp build/bin/orchestrator /usr/local/orchestrator/
+ cd /
+ apk del .build-deps
```

/cc @renecannao 