### PR TITLE
Simplify orchestrator container

### DIFF
--- a/conf/orchestrator/Dockerfile
+++ b/conf/orchestrator/Dockerfile
@@ -1,28 +1,6 @@
-FROM alpine:latest
+# Use stable release of orchestrator
+FROM openarkcode/orchestrator:latest
 
-EXPOSE 3000
-
-ENV GOPATH=/tmp/go
-
-RUN set -ex \
-    && apk add --update --no-cache bash \
-    && apk add --update --no-cache --virtual .build-deps \
-        rsync \
-        git \
-        go \
-        build-base \
-    && apk add mysql-client \
-    && cd /tmp \
-    && { go get -d github.com/openark/orchestrator ; : ; } \
-    && cd $GOPATH/src/github.com/openark/orchestrator \
-    && bash build.sh -b \
-    && mkdir -p /usr/local/orchestrator \
-    && cp build/bin/orchestrator /usr/local/orchestrator/ \
-    && cd / \
-    && apk del .build-deps \
-    && rm -rf /tmp/* \
-    && mkdir -p /var/lib/orchestrator
-
-WORKDIR /usr/local/orchestrator
-CMD /usr/local/orchestrator/orchestrator http
-
+# Needed because upstream Dockerfile doesn't create this directory, so our config
+# breaks the container.
+RUN mkdir -p /var/lib/orchestrator


### PR DESCRIPTION
The current configuration will not build because of a recent orchestrator requirement for golang 1.14, and the current alpine image only supports 1.13.

Rather than maintaining a separate orchestrator build, use openark's orchestrator container. We still have to build it to add the `/var/lib/orchestrator` directory, otherwise the container won't start with the current configuration.

Other benefits to using the upstream:
- webui works (previously ours didn't copy the 'resources' directory required for the webUI)
- fresh deployment is faster, since it doesn't have to build the binary x3

*Note:* The latest orchestrator container is not based on the master branch, but rather the most recent GA release. This means it doesn't need to take into account the current 1.14 golang requirement at the moment.