### PR TITLE
Enabling use of environment variables to override benchmark variables.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.benchmark_constants
+:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .benchmark_constants
-:

--- a/bin/docker-benchmark.bash
+++ b/bin/docker-benchmark.bash
@@ -1,23 +1,26 @@
 #!/bin/bash
 . constants
 
-PREP_THREADS=10
-RUN_THREADS=2
-NUM_TABLES=10
-SIZE_TABLES=10000
-REPORT_INTERVAL=5
-TIME=60
+# Override these defaults by exporting them in the command line prior to
+# running the script
+PREP_THREADS=${PREP_THREADS:=10}
+RUN_THREADS=${RUN_THREADS:=2}
+NUM_TABLES=${NUM_TABLES:=10}
+SIZE_TABLES=${SIZE_TABLES:=10000}
+REPORT_INTERVAL=${REPORT_INTERVAL:=5}
+TIME=${TIME:=60}
+BENCH_TEST=${BENCH_TEST:="/usr/share/sysbench/oltp_read_write.lua"}
 
 printf "$RED[$(date)] Dropping 'sysbench' schema if present and preparing test dataset:$NORMAL\n"
 mysql -h127.0.0.1 -P16033 -uroot -p$MYSQL_PWD -e"DROP DATABASE IF EXISTS sysbench; CREATE DATABASE IF NOT EXISTS sysbench"
 
 printf "$POWDER_BLUE[$(date)] Running Sysbench Benchmarks against ProxySQL:"
-sysbench /usr/share/sysbench/oltp_read_write.lua --table-size=$SIZE_TABLES --tables=$NUM_TABLES --threads=$PREP_THREADS \
+sysbench $BENCH_TEST --table-size=$SIZE_TABLES --tables=$NUM_TABLES --threads=$PREP_THREADS \
  --mysql-db=sysbench --mysql-user=root --mysql-password=$MYSQL_PWD --mysql-host=127.0.0.1 --mysql-port=16033 --db-driver=mysql prepare
 
 sleep 5
 
-sysbench /usr/share/sysbench/oltp_read_write.lua --table-size=$SIZE_TABLES --tables=$NUM_TABLES --threads=$RUN_THREADS \
+sysbench $BENCH_TEST --table-size=$SIZE_TABLES --tables=$NUM_TABLES --threads=$RUN_THREADS \
  --mysql-db=sysbench --mysql-user=root --mysql-password=$MYSQL_PWD --mysql-host=127.0.0.1 --mysql-port=16033 --skip_trx=on \
  --time=$TIME --report-interval=$REPORT_INTERVAL --db-driver=mysql run
 


### PR DESCRIPTION
This PR enables using environment variables to override the sysbench test or other settings without modifying the script.

You can set them as part of running the script:
```
BENCH_TEST=oltp_read_only ./bin/docker-benchmark.bash
```

or add your own `.benchmark_constants` (ignored by git) and source it prior to running the script:

```
. .benchmark_constants
./bin/docker-benchmark.bash
```