### PR TITLE
Galera Dockerfile fix

### DIFF
--- a/conf/mysql/Dockerfile
+++ b/conf/mysql/Dockerfile
@@ -15,6 +15,6 @@ RUN apt-get update
 RUN apt-get install -y galera-4 galera-arbitrator-4 mysql-wsrep-8.0 rsync
 
 RUN chown -R mysql:mysql /var/lib/mysql
-RUN mkdir /var/run/mysqld/ && chown -R mysql:mysql /var/run/mysqld
+RUN mkdir -p /var/run/mysqld/ && chown -R mysql:mysql /var/run/mysqld
 
 ENTRYPOINT ["mysqld"]


### PR DESCRIPTION
I ran into an issue when the Dockerfile built for one of the containers, it claimed the `/var/lib/mysql` directory already existed and error'd out. 

This should fix that.