### PR TITLE
Improving Galera build

### DIFF
--- a/conf/mysql/Dockerfile
+++ b/conf/mysql/Dockerfile
@@ -15,6 +15,6 @@ RUN apt-get update
 RUN apt-get install -y galera-4 galera-arbitrator-4 mysql-wsrep-8.0 rsync
 
 RUN chown -R mysql:mysql /var/lib/mysql
-RUN mkdir /var/run/mysqld/ && chown -R mysql:mysql /var/run/mysqld
+RUN mkdir -p /var/run/mysqld/ && chown -R mysql:mysql /var/run/mysqld
 
 ENTRYPOINT ["mysqld"]

--- a/conf/mysql/Dockerfile
+++ b/conf/mysql/Dockerfile
@@ -4,19 +4,21 @@ MAINTAINER Nick Vyzas <nick@proxysql.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update
-RUN apt-get install -y  software-properties-common
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv BC19DDBA
-RUN add-apt-repository 'deb https://releases.galeracluster.com/galera-4/ubuntu bionic main'
-RUN add-apt-repository 'deb https://releases.galeracluster.com/mysql-wsrep-8.0/ubuntu bionic main'
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv BC19DDBA && \
+    add-apt-repository 'deb https://releases.galeracluster.com/galera-4/ubuntu bionic main' && \
+    add-apt-repository 'deb https://releases.galeracluster.com/mysql-wsrep-8.0/ubuntu bionic main' && \
+    apt-get update && \
+    apt-get install -y galera-4 galera-arbitrator-4 mysql-wsrep-8.0 rsync && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update
-RUN apt-get install -y galera-4 galera-arbitrator-4 mysql-wsrep-8.0 rsync
-
-RUN chown -R mysql:mysql /var/lib/mysql
-RUN mkdir -p /var/run/mysqld/ && chown -R mysql:mysql /var/run/mysqld
-
-RUN apt-get clean
+RUN chown -R mysql:mysql /var/lib/mysql && \
+    mkdir -p /var/run/mysqld/ && \
+    chown -R mysql:mysql /var/run/mysqld
 
 ENTRYPOINT ["mysqld"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "2.0"
 services:
   mysql1:
+    image: "proxysql/galera:latest"
     build: ./conf/mysql
     ports:
       - "13306:3306"
@@ -11,6 +12,7 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=root
   mysql2:
+    image: "proxysql/galera:latest"
     build: ./conf/mysql
     ports:
       - "13307:3306"
@@ -23,6 +25,7 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=root
   mysql3:
+    image: "proxysql/galera:latest"
     build: ./conf/mysql
     ports:
       - "13308:3306"


### PR DESCRIPTION
- Slight clean up of image size in the Dockerfile
- Docker-compose file allows the init to only build the image once if necessary, not once per galera container.